### PR TITLE
Allow to defer middleware or end after successful compile

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -18,6 +18,9 @@ function optionsWithDefaults (options) {
   if (typeof stats === "object" && stats.context === undefined) {
     stats.context = process.cwd();
   }
+  if (options.defer === undefined) {
+    options.defer = true;
+  }
   return options;
 }
 
@@ -106,6 +109,10 @@ function createRealMiddleware (middleware) {
       return;
     }
 
+    if (!!middleware.options.defer) {
+        yield next;
+    }
+
     // server content
     this.set("Access-Control-Allow-Origin", "*"); // To support XHR, etc.
     this.set("Content-Type", mime.lookup(filename));
@@ -113,7 +120,6 @@ function createRealMiddleware (middleware) {
       this.set(middleware.options.headers);
     }
     this.body = middleware.fileSystem.readFileSync(filename);
-    yield next;
   };
 }
 


### PR DESCRIPTION
The option `defer` was added to the middleware, which allows to control, if further processing through other middlewares should be allowed, before the output is send out. If the `defer` option is set to `false` the middleware will stop the processing chain once a valid webpack bundle is to be served. Usually this is what you might want, as no further processing is usually needed in this case.

However the default of `defer: true` should mostly mimic the old behavior, while still providing a more meaningful handling, by traversing the middleware chain *before* rendering the output.